### PR TITLE
Add template name to htmlbars compiled templates

### DIFF
--- a/lib/ember/handlebars/helper.rb
+++ b/lib/ember/handlebars/helper.rb
@@ -55,12 +55,12 @@ module Ember
         "Handlebars.template(#{Barber::Precompiler.compile(string)});"
       end
 
-      def compile_ember_handlebars(string, ember_template = 'Handlebars')
-        "Ember.#{ember_template}.compile(#{indent(string).inspect});"
+      def compile_ember_handlebars(string, ember_template_engine = 'Handlebars', options = nil)
+        "Ember.#{ember_template_engine}.compile(#{indent(string).inspect}, #{options.to_json});"
       end
 
-      def precompile_ember_handlebars(string, ember_template = 'Handlebars')
-        "Ember.#{ember_template}.template(#{Barber::Ember::Precompiler.compile(string)});"
+      def precompile_ember_handlebars(string, ember_template_engine = 'Handlebars', options = nil)
+        "Ember.#{ember_template_engine}.template(#{Barber::Ember::Precompiler.compile(string, options)});"
       end
 
       def indent(string)

--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -60,13 +60,13 @@ module Ember
           if raw
             template = precompile_handlebars(template)
           else
-            template = precompile_ember_handlebars(template, config.ember_template, input)
+            template = precompile_ember_handlebars(template, config.ember_template, input, {moduleName: template_path(actual_name(input), config)})
           end
         else
           if raw
             template = compile_handlebars(data)
           else
-            template = compile_ember_handlebars(template, config.ember_template)
+            template = compile_ember_handlebars(template, config.ember_template, {moduleName: template_path(actual_name(input), config)})
           end
         end
 
@@ -97,7 +97,7 @@ module Ember
         end
       end
 
-      def precompile_ember_handlebars(template, ember_template, input)
+      def precompile_ember_handlebars(template, ember_template, input, options = nil)
         dependencies = [
           Barber::Ember::Precompiler.compiler_version,
           ember_template,
@@ -105,7 +105,7 @@ module Ember
         ]
 
         input[:cache].fetch(_cache_key + dependencies) do
-          super(template, ember_template)
+          super(template, ember_template, options)
         end
       end
 


### PR DESCRIPTION
Those changes make template compilation process produce `moduleName`
meta key in the result.
This make possible to ember-inspector inspect the app view tree and
fixes the issue reported in ember-inspector (emberjs/ember-inspector#419) and fixes #13

those changes have to be used in combination with changes in barber gem
from this pull request tchak/barber#53.
