### PR TITLE
Attempt to bump sprockets version

### DIFF
--- a/ember-handlebars-template.gemspec
+++ b/ember-handlebars-template.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sprockets', '>= 3.3', '< 3.6'
+  spec.add_dependency 'sprockets', '>= 3.3', '< 5'
   spec.add_dependency 'barber', '>= 0.11.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
This works for sprockets master. The only other change would likely be to the README or docs:

```
Rails.application.config.assets.configure do |c|
  c.register_mime_type 'text/x-handlebars-template', extensions: ['.hbs', '.handlebars']
  c.register_transformer 'text/x-handlebars-template', 'application/javascript', Ember::Handlebars::Template
end
```

Resolves #16.
