### PR TITLE
Remove compatibility for old Sprockets

### DIFF
--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -67,7 +67,7 @@ module Ember
           template = mustache_to_handlebars(filename, data)
         end
 
-        template_name = actual_name(input)
+        template_name = input[:name]
 
         module_name =
           case config.output_type
@@ -140,20 +140,6 @@ module Ember
           VERSION,
           Barber::VERSION
         ]
-      end
-
-      def actual_name(input)
-        actual_name = input[:name]
-
-        if input[:filename][File.expand_path(input[:name] + '/index', input[:load_path])]
-          if actual_name == '.'
-            actual_name = 'index'
-          else
-            actual_name += '/index'
-          end
-        end
-
-        actual_name
       end
     end
   end


### PR DESCRIPTION
This is a workaround to avoid logical path normalization.
This is unnecessary since Sprockets 3.1.0.

> Removed "index" logical path normalization. Asset#logical_path is always the full logical path to the index file.

ref: https://github.com/rails/sprockets/blob/v3.1.0/CHANGELOG.md
