### PR TITLE
Fix template compilation for old ember-source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
 env:
   matrix:
     - SPROCKETS_VERSION="~> 3.3.0"
-    - SPROCKETS_VERSION="~> 3.4.0"
-    - SPROCKETS_VERSION="~> 3.5.0"
-    - SPROCKETS_VERSION="~> 3.6.0"
     - SPROCKETS_VERSION="~> 3.7.0"
     - SPROCKETS_VERSION="~> 4.0.0.beta2"
+    - EMBER_SOURCE_VERSION="~> 1.13"
+    - EMBER_SOURCE_VERSION="~> 2.6"
+    - EMBER_SOURCE_VERSION="~> 2.10"

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rack', '~> 1.6' if RUBY_VERSION < '2.2'
+gem 'ember-source', ENV['EMBER_SOURCE_VERSION'] if ENV['EMBER_SOURCE_VERSION']
 gem 'sprockets', ENV['SPROCKETS_VERSION'] if ENV['SPROCKETS_VERSION']

--- a/lib/ember/handlebars/template.rb
+++ b/lib/ember/handlebars/template.rb
@@ -80,7 +80,7 @@ module Ember
             raise "Unsupported `output_type`: #{config.output_type}"
           end
 
-        meta = {moduleName: module_name}
+        meta = meta_supported? ? {moduleName: module_name} : false
 
         if config.precompile
           if raw
@@ -185,6 +185,10 @@ module Ember
           VERSION,
           Barber::VERSION
         ]
+      end
+
+      def meta_supported?
+        Gem::Version.new(Ember::VERSION) >= Gem::Version.new('2.7.0')
       end
     end
   end

--- a/test/test_ember_handlebars_template.rb
+++ b/test/test_ember_handlebars_template.rb
@@ -132,7 +132,7 @@ class TestEmberHandlebarsTemplate < Minitest::Test
 
     assert_equal 'application/javascript', asset.content_type
     assert_match %r{Ember.TEMPLATES\["hi"\]}, asset.to_s
-    assert_match %r{"moduleName": *"hi"}, asset.to_s
+    assert_match %r{"moduleName": *"hi"}, asset.to_s if meta_supported?
   end
 
   def test_should_have_module_name_with_AMD_output
@@ -141,7 +141,7 @@ class TestEmberHandlebarsTemplate < Minitest::Test
 
       assert_equal 'application/javascript', asset.content_type
       assert_match %r{define\('app/templates/hi'}, asset.to_s
-      assert_match %r{"moduleName": *"app/templates/hi"}, asset.to_s
+      assert_match %r{"moduleName": *"app/templates/hi"}, asset.to_s if meta_supported?
     end
   end
 
@@ -246,5 +246,9 @@ class TestEmberHandlebarsTemplate < Minitest::Test
     yield
   ensure
     config.raw_template_namespace = old
+  end
+
+  def meta_supported?
+    Gem::Version.new(Ember::VERSION) >= Gem::Version.new('2.7.0')
   end
 end


### PR DESCRIPTION
In older than 2.7, the precompiled template is broken when meta option (such as `{moduleName: 'name'}`) is given to ember-template-compiler.

Code:
``` ruby
Ember::VERSION #=> 2.6
Barber::Ember::Precompiler.compile('{{hi}}', {some: 'option'})
```

Expected:
```
"(function() {...}"
```

Actual:
```
"[object Object]"
```

ember-template-compiler expects `false` value as second argument on precompile.
So I ignore option for older ember.

Fixes https://github.com/emberjs/ember-rails/issues/535